### PR TITLE
Add support for client id and secret env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ auth:
     org: $GITHUB_OAUTH_ORG # required, people within this org will be able to auth
 ```
 
-When creating the OAuth app at [github.com](https://github.com/settings/developers), use  
+The values for `client-id` and `client-secret` can either be an environment variable where the value is stored, or the value itself.
+
+When creating the OAuth app at [github.com](https://github.com/settings/developers), use
 ```
 REGISTRY_URL/-/oauth/callback
 ```  

--- a/src/server/cli-support/SinopiaGithubOAuthCliSupport.ts
+++ b/src/server/cli-support/SinopiaGithubOAuthCliSupport.ts
@@ -22,8 +22,8 @@ export class SinopiaGithubOAuthCliSupport implements MiddlewarePlugin {
 
     app.use("/-/oauth/callback/cli", async (req: Request, res: Response, next: NextFunction) => {
       const code = req.query.code
-      const clientId = this.config["client-id"]
-      const clientSecret = this.config["client-secret"]
+      const clientId = process.env[this.config["client-id"]] || this.config["client-id"]
+      const clientSecret = process.env[this.config["client-secret"]] || this.config["client-secret"]
 
       try {
         const oauth = await this.github.requestAccessToken(code, clientId, clientSecret)

--- a/src/server/plugin/AuthorizeMiddleware.ts
+++ b/src/server/plugin/AuthorizeMiddleware.ts
@@ -23,7 +23,7 @@ export class AuthorizeMiddleware {
   public middleware: Handler = (req: Request, res: Response, next) => {
     const id = (req.params.id || "")
     const url = "https://github.com/login/oauth/authorize?" + querystring.stringify({
-      client_id: this.config["client-id"],
+      client_id: process.env[this.config["client-id"]] || this.config["client-id"],
       redirect_uri: this.getRedirectUrl(req) + (id ? `/${id}` : ""),
       scope: "read:org",
     })

--- a/src/server/plugin/CallbackMiddleware.ts
+++ b/src/server/plugin/CallbackMiddleware.ts
@@ -30,8 +30,8 @@ export class CallbackMiddleware {
    */
   public middleware: Handler = async (req: Request, res: Response, next: NextFunction) => {
     const code = req.query.code
-    const clientId = this.config["client-id"]
-    const clientSecret = this.config["client-secret"]
+    const clientId = process.env[this.config["client-id"]] || this.config["client-id"]
+    const clientSecret = process.env[this.config["client-secret"]] || this.config["client-secret"]
 
     try {
       const oauth = await this.github.requestAccessToken(code, clientId, clientSecret)


### PR DESCRIPTION
Check if an env variable exists for the `client-id` and `client-secret`
value. If it does, use the value stored in the environment. Otherwise,
use the value in the config directly.

No more committing secrets to public repositories :tada:

Happy to hear any feedback!