### PR TITLE
support login button click on firefox

### DIFF
--- a/src/client/script.ts
+++ b/src/client/script.ts
@@ -10,7 +10,8 @@ interface QueryParams {
  */
 ; (() => {
   const interruptLoginButtonClick = (e) => {
-    for (const element of e.path) {
+    const path = e.path || (e.composedPath && e.composedPath())
+    for (const element of path) {
       if (element.classList && element.classList.contains("header-button-login")) {
         e.preventDefault()
         e.stopPropagation()


### PR DESCRIPTION
event.path is non-standard and supported by chrome only. composedPath() is the standard.

See also https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath and
https://stackoverflow.com/questions/39245488/event-path-undefined-with-firefox-and-vue-js