### PR TITLE
Upgrade lodash to address security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "chalk": "^2.4.2",
     "express": "^4.17.0",
     "got": "^9.6.0",
-    "lodash": "^4.17.5"
+    "lodash": "4.17.15"
   },
   "devDependencies": {
     "@n4bb12/config-tslint": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2494,10 +2494,15 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.11, lodash@^4.17.11, lodash@^4.17.5:
+lodash@4.17.11, lodash@^4.17.11:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
+lodash@4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 log-symbols@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
To address the following warning:

![image](https://user-images.githubusercontent.com/7403845/61561372-ad533700-aa23-11e9-85df-9050100ad212.png)
