### PR TITLE
WIP Users that don't belong to the specified organization shouldn't see the list of packages.

### DIFF
--- a/src/server/plugin/Plugin.ts
+++ b/src/server/plugin/Plugin.ts
@@ -98,7 +98,7 @@ export default class GithubOauthUiPlugin implements MiddlewarePlugin, AuthPlugin
       cb(null, details.orgNames)
     } else {
       log(`Unauthenticated: user "${username}" is not a member of "${requiredOrg}"`)
-      cb(null, false)
+      cb('Access denied!', false)
     }
   }
 
@@ -114,7 +114,7 @@ export default class GithubOauthUiPlugin implements MiddlewarePlugin, AuthPlugin
       cb(null, user.groups)
     } else {
       log(`Access denied: user "${user.name}" is not a member of "${this.config.org}"`)
-      cb(null, false)
+      cb('Access denied!', false)
     }
   }
 


### PR DESCRIPTION
Hi Abraham,

Great work on the library!
I believe I found a bug and also a quick fix for it.

**Explanation of the bug**
Our Verdaccio config has access & publish properties set to **$authenticated**.
When the user is not logged in and they visit our registry, the registry won't show any packages and that is the way I expected it to be.

But when a user that doesn't belong to our organization logs in, they can see the list of the packages, but on the server log I can see that it logs `Access denied: user username is not a member of organization.`.

Therefore, I found out that when we don't return null but we return an error message, this problem goes away.

For the record I'm using Verdaccio 3.13.1 and the latest version of your library.