### PR TITLE
Apply better support info for Verdaccio 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "verdaccio-htpasswd": "^8.2.0"
   },
   "peerDependencies": {
-    "express": "4",
     "lodash": "4",
     "verdaccio": "3 || 4"
   },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "chalk": "^2.4.2",
+    "express": "^4.17.0",
     "global-agent": "^2.1.5",
     "got": "^9.6.0",
     "memory-cache": "^0.2.0",
@@ -62,7 +63,6 @@
     "babel-jest": "^24.9.0",
     "codecov": "^3.6.1",
     "core-js": "^3.3.4",
-    "express": "^4.17.0",
     "jest": "^24.9.0",
     "lodash": "4.17.15",
     "nodemon": "^1.18.10",

--- a/src/client/plugin/usage-info.ts
+++ b/src/client/plugin/usage-info.ts
@@ -9,7 +9,11 @@ export function getUsageInfo() {
     return "Click the login button to authenticate with GitHub."
   }
 
-  const configBase = "//" + location.host + location.pathname
+  const configBase = (window as any).VERDACCIO_API_URL
+    ? (window as any).VERDACCIO_API_URL
+      .replace(/^https?/, "")
+      .replace(/\/-\/verdaccio\//, "")
+    : `//${location.host}${location.pathname}`
   const authToken = localStorage.getItem("npm")
   return [
     `npm config set ${configBase}:_authToken "${authToken}"`,

--- a/src/client/plugin/usage-info.ts
+++ b/src/client/plugin/usage-info.ts
@@ -11,8 +11,8 @@ export function getUsageInfo() {
 
   const configBase = (window as any).VERDACCIO_API_URL
     ? (window as any).VERDACCIO_API_URL
-      .replace(/^https?/, "")
-      .replace(/\/-\/verdaccio\//, "")
+      .replace(/^https?:/, "")
+      .replace(/-\/verdaccio\/$/, "")
     : `//${location.host}${location.pathname}`
   const authToken = localStorage.getItem("npm")
   return [

--- a/src/client/verdaccio-4.ts
+++ b/src/client/verdaccio-4.ts
@@ -22,10 +22,17 @@ function modifyUsageInfoNodes() {
   const loggedIn = isLoggedIn()
 
   const infoElements = document.querySelectorAll(usageInfoSelector)
-  const cachedParent = Array.prototype.find.call(infoElements, node => node.innerText.match(
+  const firstUsageInfoEl = Array.prototype.find.call(infoElements, node => node.innerText.match(
     // This checks for an element showing instructions to set the registry URL
     /((npm|pnpm) set|(yarn) config set)/,
-  )).parentElement as HTMLDivElement
+  ))
+
+  // We can't find any element related to usage instructions
+  if (!firstUsageInfoEl) {
+    return
+  }
+
+  const cachedParent = firstUsageInfoEl.parentElement as HTMLDivElement
 
   infoElements.forEach((node => {
     const infoEl = node as HTMLSpanElement

--- a/src/client/verdaccio-4.ts
+++ b/src/client/verdaccio-4.ts
@@ -1,7 +1,6 @@
 import { getUsageInfo, init, isLoggedIn } from "./plugin"
 
 const usageInfoSelector = "#help-card .MuiCardContent-root span, .MuiDialogContent-root .MuiTypography-root span"
-const randomId = "Os1waV6BSoZQKfFwNlIwS"
 
 // copied from here as it needs to be the same behaviour
 // https://github.com/verdaccio/ui/blob/master/src/utils/cli-utils.ts
@@ -18,38 +17,56 @@ export function copyToClipboard(text: string) {
   document.body.removeChild(node)
 }
 
-function markUsageInfoNodes() {
-  document.querySelectorAll(usageInfoSelector).forEach(node => {
-    const infoEl = node as HTMLSpanElement
-
-    if (infoEl.innerText.includes("adduser")) {
-      infoEl.classList.add(randomId)
-    }
-  })
-}
-
 function modifyUsageInfoNodes() {
   const usageInfo = getUsageInfo()
   const loggedIn = isLoggedIn()
 
-  document.querySelectorAll("." + randomId).forEach(node => {
+  const infoElements = document.querySelectorAll(usageInfoSelector)
+  let packageManager: "npm" | "pnpm" | "yarn" | undefined
+  const cachedParent = Array.prototype.find.call(infoElements, node => {
+    const match = node.innerText.match(
+      // This checks for an element showing instructions to set the registry URL
+      /((npm|pnpm) set|(yarn) config set)/,
+    )
+    // When it matches, it can either be:
+    // 1. The second capture group: npm/pnpm
+    // 2. The third capture group: yarn
+    packageManager = match ? (match[1] || match[2]) : undefined
+    return !!match
+  }).parentElement as HTMLDivElement
+
+  infoElements.forEach((node => {
     const infoEl = node as HTMLSpanElement
-    const parentEl = infoEl.parentElement as HTMLDivElement
-    const copyEl = parentEl.querySelector("button") as HTMLButtonElement
-
-    infoEl.innerText = usageInfo
-
-    copyEl.style.visibility = loggedIn ? "visible" : "hidden"
-    copyEl.onclick = e => {
-      e.preventDefault()
-      e.stopPropagation()
-      copyToClipboard(usageInfo)
+    if (
+      // We only match lines related to bundler commands
+      infoEl.innerText.match(/^(npm|pnpm|yarn)/) &&
+      // And only commands that are shown in the popup overlay, to prevent overriding the help box
+      (infoEl.innerText.includes("adduser") || infoEl.innerText.includes("set password"))
+    ) {
+      infoEl.parentElement!.parentElement!.removeChild(node.parentElement as HTMLDivElement)
     }
-  })
+  }))
+
+  if (cachedParent) {
+    usageInfo.split("\n").forEach(info => {
+      const clonedNode = cachedParent.cloneNode(true) as HTMLDivElement
+      const textElem = clonedNode.querySelector("span") as HTMLSpanElement
+      const copyEl = clonedNode.querySelector("button") as HTMLButtonElement
+
+      // If cachedParent is defined, packageManager should be defined
+      textElem.innerText = packageManager ? info.replace(/^npm/, packageManager) : info
+
+      copyEl.style.visibility = loggedIn ? "visible" : "hidden"
+      copyEl.onclick = e => {
+        e.preventDefault()
+        e.stopPropagation()
+        copyToClipboard(info)
+      }
+    })
+  }
 }
 
 function updateUsageInfo() {
-  markUsageInfoNodes()
   modifyUsageInfoNodes()
 }
 

--- a/src/client/verdaccio-4.ts
+++ b/src/client/verdaccio-4.ts
@@ -22,18 +22,10 @@ function modifyUsageInfoNodes() {
   const loggedIn = isLoggedIn()
 
   const infoElements = document.querySelectorAll(usageInfoSelector)
-  let packageManager: "npm" | "pnpm" | "yarn" | undefined
-  const cachedParent = Array.prototype.find.call(infoElements, node => {
-    const match = node.innerText.match(
-      // This checks for an element showing instructions to set the registry URL
-      /((npm|pnpm) set|(yarn) config set)/,
-    )
-    // When it matches, it can either be:
-    // 1. The second capture group: npm/pnpm
-    // 2. The third capture group: yarn
-    packageManager = match ? (match[1] || match[2]) : undefined
-    return !!match
-  }).parentElement as HTMLDivElement
+  const cachedParent = Array.prototype.find.call(infoElements, node => node.innerText.match(
+    // This checks for an element showing instructions to set the registry URL
+    /((npm|pnpm) set|(yarn) config set)/,
+  )).parentElement as HTMLDivElement
 
   infoElements.forEach((node => {
     const infoEl = node as HTMLSpanElement
@@ -53,10 +45,9 @@ function modifyUsageInfoNodes() {
       const textElem = clonedNode.querySelector("span") as HTMLSpanElement
       const copyEl = clonedNode.querySelector("button") as HTMLButtonElement
 
-      // If cachedParent is defined, packageManager should be defined
-      textElem.innerText = packageManager ? info.replace(/^npm/, packageManager) : info
+      textElem.innerText = info
 
-      copyEl.style.visibility = loggedIn ? "visible" : "hidden"
+      copyEl.style.display = loggedIn ? "block" : "none"
       copyEl.onclick = e => {
         e.preventDefault()
         e.stopPropagation()

--- a/src/server/flows/WebFlow.ts
+++ b/src/server/flows/WebFlow.ts
@@ -60,7 +60,7 @@ export class WebFlow implements IPluginMiddleware<any> {
    * We issue a JWT using these values and pass them back to the frontend as
    * query parameters so they can be stored in the browser.
    *
-   * The username and token are encryped and base64 encoded to form a token for
+   * The username and token are encrypted and base64 encoded to form a token for
    * the npm CLI.
    *
    * There is no need to later decode and decrypt the token. This process is


### PR DESCRIPTION
Hi! I really appreciate the work done in this plugin and we are currently using this for our own private registry. However - we realized a few things that are misleading to the users. This PR aims to fix that presentation issue so that the registration of the GitHub OAuth flow is easier.

Patches applied in the PR:
- Added `express` as a dependency instead of a peer dependency because the CLI needs it (`npx` will not install `devDependencies` nor `peerDependencies`)
- Added better registry URL parsing from the global `VERDACCIO_API_URL` so that clicking for info in the package page won't get the wrong URL
- Added proper parsing for the info shown, with each command as a new line, as well as support for other package bundlers (`npm` as is, also for `pnpm` and `yarn`)