### PR TITLE
fix: init button selectors broken in latest version of verdaccio

### DIFF
--- a/src/client/verdaccio-4.ts
+++ b/src/client/verdaccio-4.ts
@@ -83,7 +83,7 @@ function updateUsageInfo() {
 }
 
 init({
-  loginButton: "#header--button-login",
-  logoutButton: "#header--button-logout",
+  loginButton: "#header--button-login, [data-testid='header--button-login']",
+  logoutButton: "#header--button-logout, [data-testid='header--button-logout']",
   updateUsageInfo,
 })


### PR DESCRIPTION
Fixes #39 while remaining backward compatible.