### PR TITLE
added teams as group

### DIFF
--- a/src/server/flows/CliFlow.ts
+++ b/src/server/flows/CliFlow.ts
@@ -38,7 +38,7 @@ export class CliFlow implements IPluginMiddleware<any> {
       const teams = await this.provider.getTeams(username, getConfig(this.provider.getConf(), "org"), token)
 
       if (this.core.authenticate(username, groups, teams)) {
-        const user = this.core.createAuthenticatedUser(username)
+        const user = this.core.createAuthenticatedUser(username, teams)
         const npmToken = await this.verdaccio.issueNpmToken(token, user)
 
         params.status = "success"

--- a/src/server/flows/WebFlow.ts
+++ b/src/server/flows/WebFlow.ts
@@ -63,7 +63,7 @@ export class WebFlow implements IPluginMiddleware<any> {
       const teams = await this.provider.getTeams(username, getConfig(this.provider.getConf(), "org"), token)
 
       if (this.core.authenticate(username, groups, teams)) {
-        const ui = await this.core.createUiCallbackUrl(token, username)
+        const ui = await this.core.createUiCallbackUrl(token, username, teams)
 
         res.redirect(ui)
       } else {

--- a/src/server/github/AuthProvider.ts
+++ b/src/server/github/AuthProvider.ts
@@ -66,7 +66,7 @@ export class GitHubAuthProvider implements AuthProvider {
   }
 
   async getTeams(username: string, org: string, token: string) {
-    const teams = await this.client.requestUserTeams(username, org, token)
-    return teams.data.organization.teams.edges.map(it => it.node.name)
+    const teams = await this.client.requestUserTeams(username, org, '', token)
+    return teams
   }
 }

--- a/src/server/github/Team.ts
+++ b/src/server/github/Team.ts
@@ -1,0 +1,70 @@
+import got from "got"
+
+export interface IMemberNode {
+  node: {
+    name: string;
+    slug: string;
+  };
+}
+
+export interface IResponseData {
+  data: {
+    organization: {
+      teams: {
+        totalCount: number;
+        pageInfo: {
+          hasNextPage: boolean;
+          endCursor: string;
+        };
+        edges: Array<IMemberNode>;
+      }
+    }
+  }
+}
+
+export async function  getTeamsByUser( username: string, org: string, graphqlBaseUrl: string, endCursor: string, accessToken: string): Promise<IResponseData> {
+    const url = graphqlBaseUrl + "/graphql"
+    const queryParams = [`userLogins: ["${username}"]`]
+    const paginationCount = 100
+    if (endCursor) {
+      queryParams.push(`after: "${endCursor}"`);
+    }
+    const pagination = `first: ${paginationCount}`
+    const query = `{ 
+          organization(login: "${org}") { 
+            teams(${[pagination, ...queryParams].join(', ')}) { 
+              totalCount 
+              edges { 
+                node {
+                  name 
+                  slug 
+                } 
+              } 
+              pageInfo { 
+                hasNextPage 
+                endCursor 
+              } 
+            } 
+          } 
+        }`
+    /*logger.log("Query: "+query)*/
+    const options = {
+      method: "POST",
+      json: {
+        query: query.replace(/[\n\r]/g, '')
+      },
+      headers: {
+        Authorization: "Bearer " + accessToken,
+      },
+      responseType: 'json'
+    } as const
+
+    try {
+          const data = await got(url, options).json()
+          return data
+
+    } catch (error) {
+          throw new Error("Failed requesting GitHub user orgs: " + error.message)
+    }
+  }
+

--- a/src/server/plugin/Plugin.ts
+++ b/src/server/plugin/Plugin.ts
@@ -52,7 +52,7 @@ export class Plugin implements IPluginMiddleware<any>, IPluginAuth<any> {
       const providerTeams = await this.cache.getTeams(username, this.config.org, token)
 
       if (this.core.authenticate(username, providerGroups, providerTeams)) {
-        const user = this.core.createAuthenticatedUser(username)
+        const user = this.core.createAuthenticatedUser(username, providerTeams)
 
         callback(null, user.real_groups)
       } else {


### PR DESCRIPTION
There are several things in your latest release which are wrong: REST API you are using for teams request will return all teams VISIBLE for user. For enterprise github my account as owner of organization may see ALL teams not only teams I am member of. There only way to get teams for user other than going through each team and get list of members - graphQL query. I modified query Bertrand used because without pagination graphQL will return only 100 first results. I am using slug instead of name for team because team name may include spaces which is not very good... I also modified team filter to accept multiple teams as filter and I added teams requested to real_group array for authorization