### PR TITLE
fix: take verdaccio version from package.json

### DIFF
--- a/src/server/plugin/Config.ts
+++ b/src/server/plugin/Config.ts
@@ -49,10 +49,11 @@ export function getConfig(config: Config, key: PluginConfigKey): string {
 }
 
 /**
- * user_agent: e.g. "verdaccio/5.0.4" --> 5
+ * e.g. "5.0.4" --> 5
  */
-export function getMajorVersion(config: VerdaccioConfig) {
-  return +config.user_agent.replace(/^verdaccio\/(\d+).\d+.\d+$/, "$1")
+export function getMajorVersion() {
+  const version = require("verdaccio/package.json").version
+  return +version.replace(/^(\d+).\d+.\d+$/, "$1")
 }
 
 //
@@ -84,7 +85,7 @@ function ensureObjectNotEmpty(config: Config, node: keyof Config) {
 }
 
 export function validateConfig(config: Config) {
-  const majorVersion = getMajorVersion(config)
+  const majorVersion = getMajorVersion()
 
   if (majorVersion < 5) {
     throw new Error("This plugin requires verdaccio 5 or above")

--- a/src/server/verdaccio/Verdaccio.ts
+++ b/src/server/verdaccio/Verdaccio.ts
@@ -28,7 +28,7 @@ function getSecurity(config: VerdaccioConfig) {
  * Abstract Verdaccio version differences and usage of all Verdaccio objects.
  */
 export class Verdaccio {
-  readonly majorVersion = getMajorVersion(this.config)
+  readonly majorVersion = getMajorVersion()
   readonly security = getSecurity(this.config)
 
   private auth!: Auth

--- a/test/server/plugin/Verdaccio/getMajorVersion.test.ts
+++ b/test/server/plugin/Verdaccio/getMajorVersion.test.ts
@@ -2,13 +2,8 @@ import { createTestVerdaccio } from "test/utils"
 
 describe("Verdaccio", () => {
   describe("getMajorVersion", () => {
-    function withConfig(config: any) {
-      return createTestVerdaccio(config).majorVersion
-    }
-
     it("correctly parses the user agent", () => {
-      expect(withConfig({ user_agent: "verdaccio/4.3.2" })).toBe(4)
-      expect(withConfig({ user_agent: "verdaccio/5.4.3" })).toBe(5)
+      expect(createTestVerdaccio().majorVersion).toBe(5)
     })
   })
 })


### PR DESCRIPTION
Fixes https://github.com/n4bb12/verdaccio-github-oauth-ui/issues/143

We now take the version from `package.json`. This is already what `verdaccio` itself does anyway to populate the user agent.