### PR TITLE
Fix login flow when session expires

### DIFF
--- a/src/client/plugin/credentials.ts
+++ b/src/client/plugin/credentials.ts
@@ -4,6 +4,8 @@
 // thinks we are logged in.
 //
 
+import { parseJwt } from "./lib"
+
 export interface Credentials {
   username: string
   uiToken: string
@@ -29,6 +31,22 @@ export function isLoggedIn() {
     !!localStorage.getItem("token") &&
     !!localStorage.getItem("npm")
   )
+}
+
+export function isTokenExpired() {
+  const token = localStorage.getItem("token")
+  if (typeof token !== "string") {
+    return true
+  }
+
+  const payload = parseJwt(token)
+  if (!payload) {
+    return true
+  }
+
+  // Report as expired before (real expiry - 30s)
+  const jsTimestamp = payload.exp * 1000 - 30000
+  return Date.now() >= jsTimestamp
 }
 
 export function validateCredentials(credentials: Credentials) {

--- a/src/client/plugin/init.ts
+++ b/src/client/plugin/init.ts
@@ -3,12 +3,17 @@ import {
   clearCredentials,
   Credentials,
   isLoggedIn,
+  isTokenExpired,
   saveCredentials,
   validateCredentials,
 } from "./credentials"
 import { interruptClick, parseCookies, retry } from "./lib"
 
 function saveAndRemoveCookies() {
+  if (isTokenExpired()) {
+    clearCredentials()
+  }
+
   if (isLoggedIn()) {
     return
   }

--- a/src/client/plugin/lib.ts
+++ b/src/client/plugin/lib.ts
@@ -15,12 +15,19 @@ export function parseCookies(cookieStr: string) {
     )
 }
 
+// This parseJWT implementation is taken from https://stackoverflow.com/a/38552302/1935971
 export function parseJwt(token: string) {
+  // JWT has 3 parts separated by ".", the payload is the base64url-encoded part in the middle
   const base64Url = token.split(".")[1]
+  // base64url replaced '+' and '/' with '-' and '_', so we undo it here
   const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/")
   const jsonPayload = decodeURIComponent(
     atob(base64)
       .split("")
+      // atob decoded the base64 string, but multi-byte characters (emojis for example)
+      // are not decoded properly. For example, "🍀" looks like "ð\x9F\x8D\x80". The next
+      // line converts bytes into URI-percent-encoded format, for example "%20" for space.
+      // Lastly, the decodeURIComponent wrapping this can correctly get a UTF-8 string.
       .map((c) => "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2))
       .join(""),
   )

--- a/src/client/plugin/lib.ts
+++ b/src/client/plugin/lib.ts
@@ -15,6 +15,19 @@ export function parseCookies(cookieStr: string) {
     )
 }
 
+export function parseJwt(token: string) {
+  const base64Url = token.split(".")[1]
+  const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/")
+  const jsonPayload = decodeURIComponent(
+    atob(base64)
+      .split("")
+      .map((c) => "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2))
+      .join(""),
+  )
+
+  return JSON.parse(jsonPayload)
+}
+
 export function retry(action: () => void) {
   for (let i = 0; i < 10; i++) {
     setTimeout(() => action(), 100 * i)

--- a/test/client/plugin/parseJwt.test.ts
+++ b/test/client/plugin/parseJwt.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest"
+import { parseJwt } from "src/client/plugin/lib"
+
+const MOCK_TOKEN =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyZWFsX2dyb3VwcyI6WyJnaXRodWIvb3JnL3Rlc3Qtb3JnIl0sIm5hbWUiOiJKb2huRG9lIiwiZ3JvdXBzIjpbIiRhbGwiLCJAYWxsIiwiJGF1dGhlbnRpY2F0ZWQiLCJAYXV0aGVudGljYXRlZCIsImdpdGh1Yi9vcmcvdGVzdC1vcmciXSwiaWF0IjoxNzE2NTIxNzY0LCJuYmYiOjE3MTY1MjE3NjQsImV4cCI6MTcxOTExMzc2NH0.O9UoSVBvKyM5UAJzoVa_kNvjJR0C06SP57nVXwzxEBY"
+
+describe("parseJwt", () => {
+  it("should decode a valid JWT token", () => {
+    const decodedToken = parseJwt(MOCK_TOKEN)
+
+    expect(decodedToken).toEqual({
+      real_groups: ["github/org/test-org"],
+      name: "JohnDoe",
+      groups: [
+        "$all",
+        "@all",
+        "$authenticated",
+        "@authenticated",
+        "github/org/test-org",
+      ],
+      iat: 1716521764,
+      nbf: 1716521764,
+      exp: 1719113764,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Clear local storage if we detect that the token is expired. Fixes #197.

## Notes
* The `isTokenExpired` treats a token as expired if we're within 30 seconds of expiry. This matches [the logic Verdaccio itself uses](https://github.com/verdaccio/verdaccio/blob/007a7bd76c0391d266fc89e5d5a5fa7192d93be2/packages/ui-components/src/utils/token.ts#L5), which is important since the UI does not match up otherwise.
* I used the `parseJwt` method [from this Stack Overflow answer](https://stackoverflow.com/a/38552302/1935971). I noticed the client code in this repo did not depend on any libraries, so I kept it that way.