### PR TITLE
fix: support Verdaccio 6.5.0 ui-options external script

### DIFF
--- a/src/server/plugin/PatchHtml.ts
+++ b/src/server/plugin/PatchHtml.ts
@@ -34,7 +34,10 @@ export class PatchHtml implements IPluginMiddleware {
   private insertTags = (req: Request, html: string | Buffer): string => {
     html = String(html)
 
-    if (!html.includes("__VERDACCIO_BASENAME_UI_OPTIONS")) {
+    if (
+      !html.includes("__VERDACCIO_BASENAME_UI_OPTIONS") &&
+      !html.includes("ui-options.js")
+    ) {
       return html
     }
 

--- a/test/server/plugin/PatchHtml/insertTags.test.ts
+++ b/test/server/plugin/PatchHtml/insertTags.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest"
+import { PatchHtml } from "src/server/plugin/PatchHtml"
+
+const scriptPattern = /verdaccio-6\.js/
+
+function createPatchHtml() {
+  const config = { url_prefix: "" } as any
+  return new PatchHtml(config)
+}
+
+function callInsertTags(html: string) {
+  const patchHtml = createPatchHtml()
+  const req = { headers: { host: "localhost:4873" }, protocol: "http" } as any
+  // Access the private method via bracket notation
+  return (patchHtml as any).insertTags(req, html)
+}
+
+// Verdaccio <=6.4 inlines the options in a <script> tag
+const legacyHtml = `
+  <!DOCTYPE html>
+  <html><head>
+    <script>window.__VERDACCIO_BASENAME_UI_OPTIONS={"base":"/"}</script>
+  </head><body><div id="root"></div></body></html>
+`
+
+// Verdaccio >=6.5 loads options from an external script
+const modernHtml = `
+  <!DOCTYPE html>
+  <html><head>
+    <script src="/-/static/ui-options.js"></script>
+  </head><body><div id="root"></div></body></html>
+`
+
+const jsonResponse = JSON.stringify({ name: "some-package", version: "1.0.0" })
+
+describe("PatchHtml - insertTags", () => {
+  it("injects the client script into legacy Verdaccio HTML (<=6.4)", () => {
+    const result = callInsertTags(legacyHtml)
+    expect(result).toMatch(scriptPattern)
+  })
+
+  it("injects the client script into modern Verdaccio HTML (>=6.5)", () => {
+    const result = callInsertTags(modernHtml)
+    expect(result).toMatch(scriptPattern)
+  })
+
+  it("does not modify non-HTML responses", () => {
+    const result = callInsertTags(jsonResponse)
+    expect(result).toBe(jsonResponse)
+  })
+})


### PR DESCRIPTION
## Problem

Verdaccio 6.5.0 moved `__VERDACCIO_BASENAME_UI_OPTIONS` from an inline `<script>` tag in the HTML to an external `ui-options.js` file (verdaccio/verdaccio@df612faef, #5792).

The `PatchHtml` guard checks for `__VERDACCIO_BASENAME_UI_OPTIONS` in the response body to detect the Verdaccio web UI HTML before injecting the plugin's client script. Since the string is no longer in the HTML, the plugin script is never injected - causing the login button to show the default username/password modal instead of redirecting to GitHub OAuth.

## Fix

Also check for `ui-options.js` in the response body, which is the new external script that Verdaccio 6.5.0 uses to load UI options. This keeps backward compatibility with Verdaccio <=6.4 (which still inlines the options).

## Test plan

- Added unit tests for `PatchHtml.insertTags` covering legacy HTML (<=6.4), modern HTML (>=6.5), and non-HTML responses
- Verified manually by running Verdaccio 6.5.0 in Docker with the patched plugin - clicking Login correctly redirects to GitHub OAuth

---                                                                                                                                                                                                  

> **Note:** I relied heavily on Claude to investigate and fix this issue. If I missed anything fundamental or you have suggestions for a better approach, feedback is very welcome!